### PR TITLE
add ingress with letsencrypt to the chart and simplify config

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -193,6 +193,19 @@ kubectl get all
     statefulset.apps/db-redis-ha-server      1/1     97s
     statefulset.apps/meter-redis-ha-server   1/1     3m34s
 
+# Install nginx-ingress
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install ingress --namespace ingress --set=podSecurityPolicy.enabled=true ingress-nginx/ingress-nginx
+```
+
+# Install cert-manager
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager --namespace cert-manager --set installCRDs=true jetstack/cert-manager
+```
 
 # Create  a minimal `kiebitz` image
 

--- a/charts/kiebitz/templates/NOTES.txt
+++ b/charts/kiebitz/templates/NOTES.txt
@@ -5,16 +5,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.storageService.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kiebitz.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.storageService.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kiebitz.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kiebitz.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.storageService.port }}
+{{- else if contains "ClusterIP" .Values.storageService.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kiebitz.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/charts/kiebitz/templates/appointments-certificate.yaml
+++ b/charts/kiebitz/templates/appointments-certificate.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.ingress.enabled .Values.ingress.certIssuerName -}}
+{{- $fullName := include "kiebitz.fullname" . -}}
+{{- $domainName := .Values.ingress.domain -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullName }}-appointments-cert
+spec:
+  secretName: {{ $fullName }}-appointments-certificate
+  issuerRef:
+    name: {{ .Values.ingress.certIssuerName }}
+  dnsNames:
+  - appointments.{{ $domainName }}
+{{- end }}

--- a/charts/kiebitz/templates/appointments-ingress.yaml
+++ b/charts/kiebitz/templates/appointments-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kiebitz.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $domainName := .Values.ingress.domain -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-appointments
   labels:
     {{- include "kiebitz.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -28,34 +28,26 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - appointments.{{ $domainName }}
+      secretName: {{ $fullName }}-appointments-certificate
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: appointments.{{ $domainName }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: /
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-appointments
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ .Values.appointmentsService.port }}
               {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              serviceName: {{ $fullName }}-appointments
+              servicePort: {{ .Values.appointmentsService.port }}
               {{- end }}
-          {{- end }}
-    {{- end }}
 {{- end }}

--- a/charts/kiebitz/templates/appointments-service.yaml
+++ b/charts/kiebitz/templates/appointments-service.yaml
@@ -1,15 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kiebitz.fullname" . }}
+  name: {{ include "kiebitz.fullname" . }}-appointments
   labels:
     {{- include "kiebitz.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.appointmentsService.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - port: {{ .Values.appointmentsService.port }}
       protocol: TCP
-      name: http
   selector:
     {{- include "kiebitz.selectorLabels" . | nindent 4 }}

--- a/charts/kiebitz/templates/issuer.yaml
+++ b/charts/kiebitz/templates/issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  # different name
+  name: {{ .Values.ingress.certIssuerName }}
+spec:
+  acme:
+    # now pointing to Let's Encrypt production API
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: {{ .Values.ingress.certEmail }}
+    privateKeySecretRef:
+      # storing key material for the ACME account in dedicated secret
+      name: account-key-prod
+    solvers:
+    - http01:
+       ingress:
+         class: nginx

--- a/charts/kiebitz/templates/storage-certificate.yaml
+++ b/charts/kiebitz/templates/storage-certificate.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.ingress.enabled .Values.ingress.certIssuerName -}}
+{{- $fullName := include "kiebitz.fullname" . -}}
+{{- $domainName := .Values.ingress.domain -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $fullName }}-storage-cert
+spec:
+  secretName: {{ $fullName }}-storage-certificate
+  issuerRef:
+    name: {{ .Values.ingress.certIssuerName }}
+  dnsNames:
+  - storage.{{ $domainName }}
+{{- end }}

--- a/charts/kiebitz/templates/storage-ingress.yaml
+++ b/charts/kiebitz/templates/storage-ingress.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kiebitz.fullname" . -}}
+{{- $domainName := .Values.ingress.domain -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-storage
+  labels:
+    {{- include "kiebitz.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - storage.{{ $domainName }}
+      secretName: {{ $fullName }}-storage-certificate
+  {{- end }}
+  rules:
+    - host: storage.{{ $domainName }}
+      http:
+        paths:
+          - path: /
+            {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-storage
+                port:
+                  number: {{ .Values.storageService.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-storage
+              servicePort: {{ .Values.storageService.port }}
+              {{- end }}
+{{- end }}

--- a/charts/kiebitz/templates/storage-service.yaml
+++ b/charts/kiebitz/templates/storage-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kiebitz.fullname" . }}-storage
+  labels:
+    {{- include "kiebitz.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.storageService.type }}
+  ports:
+    - port: {{ .Values.storageService.port }}
+      protocol: TCP
+  selector:
+    {{- include "kiebitz.selectorLabels" . | nindent 4 }}

--- a/charts/kiebitz/templates/tests/test-connection.yaml
+++ b/charts/kiebitz/templates/tests/test-connection.yaml
@@ -11,5 +11,9 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "kiebitz.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "kiebitz.fullname" . }}:{{ .Values.storageService.port }}']
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "kiebitz.fullname" . }}:{{ .Values.appointmentsService.port }}']
   restartPolicy: Never

--- a/charts/kiebitz/values.yaml
+++ b/charts/kiebitz/values.yaml
@@ -37,25 +37,24 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-service:
+storageService:
   type: ClusterIP
-  port: 80
+  port: 11111
+
+appointmentsService:
+  type: ClusterIP
+  port: 22222
 
 ingress:
-  enabled: false
-  className: ""
+  enabled: true
+  domain: impfterm.in
+  tls: true
+  certIssuerName: letsencrypt-prod
+  certEmail: kontakt@kiebitz.eu
+  className: nginx
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR adds services and an ingress configuration with letsencrypt to the deployment.

To simplify the configuration I've reduced the number of possible chart values. Subdomains for `storage` and `appointments` are configured automatically for the given `domain`.

 When the ingress is enabled, the helm chart now depends on the previous installation of `ingress-nginx` and `cert-manager`.